### PR TITLE
Add container + ABC-cluster deploy descriptor (Dockerfile, abc-app.yaml)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+**/tests
+test
+docs/*.pdf
+publication
+*.duckdb
+dstcalc.db
+.venv

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,38 @@
+# Deploying pDST-calc on ABC-cluster
+
+The app ships as a container and deploys via the `abc app` command. It is also
+runnable as a plain Docker container anywhere.
+
+## Run locally (Docker)
+
+```bash
+docker build -t pdst-calc:poc .
+docker run --rm -p 3838:3838 pdst-calc:poc
+# open http://localhost:3838
+```
+
+## Deploy on ABC-cluster (`abc app`)
+
+Apps are bring-your-own-image: build the image on the cluster build host, tag it
+for the local image store, then deploy the included `abc-app.yaml`.
+
+```bash
+# on the build host
+docker build -t pdst-calc:poc .
+docker tag  pdst-calc:poc aither.local/pdst-calc:poc
+
+# deploy (abc-apps namespace, routed at <project>-<name>.apps.<tier>…)
+abc app deploy
+abc app show pdst-calc
+```
+
+Live instance: <https://genpath-pdst-calc.apps.seedling.abc-cluster.cloud>
+
+## Notes
+
+- **Framework:** Shiny for Python, served at `/` on port `3838` (WebSocket passes
+  through the edge for interactivity).
+- **State:** the app's SQLite DB (`dstcalc.db`) + bcrypt auth are created inside
+  the container and are **ephemeral** — they reset on redeploy/restart. Mount a
+  volume (or wire persistent storage) if you need accounts/data to survive.
+- **Resources:** defaults to 1000 MHz / 2048 MiB (`abc-app.yaml`); tune as needed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Container image for the pDST-calc Shiny (Python) web app.
+# Build:  docker build -t pdst-calc:poc .
+# Run:    docker run -p 3838:3838 pdst-calc:poc   ->  http://localhost:3838
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+WORKDIR /app
+COPY . /app
+
+# Install runtime deps from the committed lockfile (no dev/lint/test groups).
+RUN uv sync --frozen --no-dev
+
+# Run the pre-built venv directly (no `uv run` re-sync at container start).
+ENV PATH="/app/.venv/bin:$PATH"
+EXPOSE 3838
+CMD ["shiny", "run", "app/shiny/app.py", "--host", "0.0.0.0", "--port", "3838"]

--- a/abc-app.yaml
+++ b/abc-app.yaml
@@ -1,0 +1,22 @@
+# abc-app.yaml — deploy descriptor for `abc app deploy` on ABC-cluster.
+# See DEPLOY.md for the full flow.
+version: "1.0"
+name: pdst-calc
+project: genpath
+framework: shiny
+
+# Bring-your-own-image (phase 1 has no cluster-side build). Build from the
+# included Dockerfile and tag it for the cluster's local image store:
+#   docker build -t pdst-calc:poc .
+#   docker tag  pdst-calc:poc aither.local/pdst-calc:poc
+image: aither.local/pdst-calc:poc
+
+port: 3838          # Shiny listen port (the container binds 0.0.0.0:3838)
+health: /           # HTTP path polled for readiness
+
+access: team        # gated to the `genpath` group
+exposure: public    # reachable on the public edge
+
+resources:
+  cpu: 1000         # MHz
+  memory: 2048      # MiB  (pandas / numpy / reportlab headroom)


### PR DESCRIPTION
Adds the bits needed to containerise and deploy pDST-calc, with no change to app code.

## Added
- **`Dockerfile`** — uv-based image; `uv sync --frozen --no-dev` then runs the pre-built venv (`shiny run app/shiny/app.py --host 0.0.0.0 --port 3838`). Runnable anywhere: `docker build -t pdst-calc:poc . && docker run -p 3838:3838 pdst-calc:poc`.
- **`.dockerignore`** — excludes `.git`, tests, doc PDFs, `*.duckdb`/`dstcalc.db`, `.venv`.
- **`abc-app.yaml`** — `abc app deploy` descriptor (framework `shiny`, port 3838, project `genpath`, 1 CPU / 2 GiB, public).
- **`DEPLOY.md`** — local-Docker + ABC-cluster (`abc app`) instructions, incl. the ephemeral SQLite/auth caveat.

## Verified
Built + deployed live on ABC-cluster — **200** at <https://genpath-pdst-calc.apps.seedling.abc-cluster.cloud> (Shiny app serving).

## Note
The app's `dstcalc.db` + bcrypt auth are created inside the container and are ephemeral (reset on redeploy). Mount a volume if persistence is needed — flagged in `DEPLOY.md`.