### PR TITLE
Add Dockerfile for containerizing the Shiny app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+**/tests
+test
+docs/*.pdf
+publication
+*.duckdb
+dstcalc.db
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ results/
 *.db
 *.sqlite
 *.sqlite3
+# Local deployment descriptors (kept out of the repo)
+abc-app.yaml
+DEPLOY.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Container image for the pDST-calc Shiny (Python) web app.
+# Build:  docker build -t pdst-calc .
+# Run:    docker run --rm -p 3838:3838 pdst-calc   ->  http://localhost:3838
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+WORKDIR /app
+COPY . /app
+
+# Install runtime deps from the committed lockfile (no dev/lint/test groups).
+RUN uv sync --frozen --no-dev
+
+# Run the pre-built venv directly (no `uv run` re-sync at container start).
+ENV PATH="/app/.venv/bin:$PATH"
+EXPOSE 3838
+CMD ["shiny", "run", "app/shiny/app.py", "--host", "0.0.0.0", "--port", "3838"]


### PR DESCRIPTION
Adds containerization for the Shiny app — no app-code changes.

## Added
- **`Dockerfile`** — uv-based image: `uv sync --frozen --no-dev`, then runs the pre-built venv (`shiny run app/shiny/app.py --host 0.0.0.0 --port 3838`). Run anywhere:
  ```bash
  docker build -t pdst-calc .
  docker run --rm -p 3838:3838 pdst-calc   # http://localhost:3838
  ```
- **`.dockerignore`** — trims `.git`, tests, doc PDFs, `*.duckdb`/`dstcalc.db`, `.venv` from the build context.
- **`.gitignore`** — ignores local deployment descriptors so they aren't committed.

Verified: the image builds and the Shiny app serves on port 3838.